### PR TITLE
Cucumber - Prevent storage of unused classes in object factory

### DIFF
--- a/cdi-test-cucumber/src/main/java/cucumber/runtime/java/cditest/CdiTestObjectFactory.java
+++ b/cdi-test-cucumber/src/main/java/cucumber/runtime/java/cditest/CdiTestObjectFactory.java
@@ -49,12 +49,15 @@ public class CdiTestObjectFactory implements ObjectFactory {
 
     @Override
     public void addClass(Class<?> clazz) {
-        LOG.info("adding " + clazz);
-        definitions.put(clazz, BeanProvider.getContextualReference(clazz, false));
+
     }
 
     @Override
     public <T> T getInstance(Class<T> clazz) {
+        if (definitions.get(clazz) == null){
+            LOG.info("adding " + clazz);
+            definitions.put(clazz, BeanProvider.getContextualReference(clazz, false));
+        }
         return (T) definitions.get(clazz);
     }
 }

--- a/cdi-test-cucumber/src/main/java/cucumber/runtime/java/cditest/CdiTestObjectFactory.java
+++ b/cdi-test-cucumber/src/main/java/cucumber/runtime/java/cditest/CdiTestObjectFactory.java
@@ -49,7 +49,6 @@ public class CdiTestObjectFactory implements ObjectFactory {
 
     @Override
     public void addClass(Class<?> clazz) {
-
     }
 
     @Override


### PR DESCRIPTION
The cucumber JavaBackend calls the addClass() method of the ObjectFactory implementation for each glue step cucumber found in the classpath. This includes glue code from not run feature files. To prevent instanciation of unused classes the map insertion should happen in the getInstance method. In which case only classes holding the feature steps specified by the used cucumber runner will be delivered.