### PR TITLE
Jakarta EE 10 support: Restore EE9 bean discovery mode and update libs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,26 @@
                 <eclipselink.version>4.0.0</eclipselink.version>
                 <smallrye.version>3.1.2</smallrye.version>
             </properties>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jakarta-ee-10</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <classifier>jakarta-ee-10</classifier>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>release</id>


### PR DESCRIPTION
This PR resolves the failing injections which occur when CDI Test runs in a CDI 4.x / Weld 5.x environment, because CDI 4.x changed the default bean-discovery-mode from 'all' to 'annotated'. Also, it upgrades the libs to run against Jakarta EE 10 Specs and Weld 5.x. Anyway, for me this seems more like a shortterm solution but should help to support Jakarta EE 10 for the moment.

fixes: #307